### PR TITLE
Add a regression test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/regression-workdir

--- a/regression.sh
+++ b/regression.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#####################################################################
+# Setup
+#####################################################################
+TOP="$(pwd)"
+
+# In order to actually run the regression tests we need to setup some
+# enviornment variables.
+export RISCV="$(pwd)/regression-workdir"
+export PATH="$RISCV/bin:$PATH"
+
+# Clean anything that was installed, just in case it's left over from
+# a previous regression test run.
+rm -rf "$RISCV"
+
+# Fetch all the latest source code and build everything that's built
+# by default.
+git submodule update --init --recursive
+./build.sh
+
+#####################################################################
+# Tests
+#####################################################################
+
+# Run the RISC-V assembly tests in Spike -- this is really just a
+# sanity test, it doesn't test a whole lot.
+cd "$TOP"/riscv-tests
+./configure
+make
+make -C isa run


### PR DESCRIPTION
This is currently very simple: it just checks out and builds the
current repository with the default configuration and then runs all
the ISA tests on Spike.  The general idea here is to put most of the
regression logic in this script, both so users can run it and so the
various regression systems don't end up with all this logic baked in.