### PR TITLE
Temporarily remove qemu from riscv-tools while rewriting qemu history.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,3 @@
 [submodule "riscv-gnu-toolchain"]
 	path = riscv-gnu-toolchain
 	url = https://github.com/riscv/riscv-gnu-toolchain.git
-[submodule "riscv-qemu"]
-	path = riscv-qemu
-	url = https://github.com/riscv/riscv-qemu

--- a/build.sh
+++ b/build.sh
@@ -11,8 +11,6 @@ build_project riscv-fesvr --prefix=$RISCV
 build_project riscv-isa-sim --prefix=$RISCV --with-fesvr=$RISCV
 build_project riscv-gnu-toolchain --prefix=$RISCV
 CC= CXX= build_project riscv-pk --prefix=$RISCV/riscv64-unknown-elf --host=riscv64-unknown-elf
-cd riscv-qemu; git update-index --assume-unchanged po/*; cd ..
-build_project riscv-qemu --prefix=$RISCV --target-list=riscv-softmmu
 build_tests
 
 echo -e "\\nRISC-V Toolchain installation completed!"


### PR DESCRIPTION
This reverts commit f1f0ae46ebc08c54079530fa1bb071ab03f55734.