### PR TITLE
Install the tests along with the other tools

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,7 @@ build_project riscv-gnu-toolchain --prefix=$RISCV
 CC= CXX= build_project riscv-pk --prefix=$RISCV/riscv64-unknown-elf --host=riscv64-unknown-elf
 build_tests
 
+mkdir -p $RISCV/riscv64-unknown-elf/share/riscv-tests
+cp -a riscv-tests/{isa,benchmarks} $RISCV/riscv64-unknown-elf/share/riscv-tests
+
 echo -e "\\nRISC-V Toolchain installation completed!"


### PR DESCRIPTION
This allows Travis to cache the built tests more easily, and we're already
doing this at the BWRC (where the tool builds were flaky).