### PR TITLE
Add a "--with-xlen" argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ env:
     - RISCV="/home/travis/riscv_install"
     - MAKEFLAGS="-j3"
     - PATH="/home/travis/riscv_install/bin:$PATH"
+  matrix:
+    - XLEN=32
+    - XLEN=64
 
 before_install:
   # make install destination
@@ -44,6 +47,6 @@ before_install:
 install: travis_wait
 
 script:
-  - ./build.sh
+  - ./build.sh --with-xlen=$XLEN
   #- cd riscv-tests/build
   #- make debug-check

--- a/build.common
+++ b/build.common
@@ -7,6 +7,16 @@ then
   exit 1
 fi
 
+XLEN=64
+while [[ "$1" != "" ]]
+do
+  case "$1" in
+  "--with-xlen=32") XLEN="32"; shift;;
+  "--with-xlen=64") XLEN="64"; shift;;
+  *) echo "Unknown argument $1"; exit 2;;
+  esac
+done
+
 # Use gmake instead of make if it exists.
 MAKE=`command -v gmake || command -v make`
 

--- a/build.sh
+++ b/build.sh
@@ -3,14 +3,14 @@
 # Script to build RISC-V ISA simulator, proxy kernel, and GNU toolchain.
 # Tools will be installed to $RISCV.
 
-. build.common
+. build.common "$@"
 
-echo "Starting RISC-V Toolchain build process"
+echo "Starting RISC-V Toolchain build process, XLEN=$XLEN"
 
 build_project riscv-fesvr --prefix=$RISCV
 build_project riscv-isa-sim --prefix=$RISCV --with-fesvr=$RISCV
-build_project riscv-gnu-toolchain --prefix=$RISCV
-CC= CXX= build_project riscv-pk --prefix=$RISCV --host=riscv64-unknown-elf
-build_project riscv-tests --prefix=$RISCV/riscv64-unknown-elf
+build_project riscv-gnu-toolchain --prefix=$RISCV --with-xlen=${XLEN}
+CC= CXX= build_project riscv-pk --prefix=$RISCV --host=riscv${XLEN}-unknown-elf
+build_project riscv-tests --prefix=$RISCV/riscv${XLEN}-unknown-elf
 
 echo -e "\\nRISC-V Toolchain installation completed!"


### PR DESCRIPTION
This should help users who are trying to build coherent 32-bit software
ecosystems.

The pk bump is to work around a compiler bug, and the riscv-tests bump is to support --with-xlen there.

Note that I can't actually run anything

```
palmer.dabbelt a2 riscv-tools $ file test
test: ELF 32-bit LSB  executable, version 1 (SYSV), statically linked, not stripped
palmer.dabbelt a2 riscv-tools $ spike --isa=rv32imafd $RISCV/riscv32-unknown-elf/bin/pk test
terminate called after throwing an instance of 'trap_store_access_fault'
```

so maybe I've screwed something up.
