### PR TITLE
Disable -Werror when building OpenOCD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@
 
 echo "Starting RISC-V Toolchain build process"
 
-build_project riscv-openocd --prefix=$RISCV --enable-remote-bitbang --enable-jtag_vpi
+build_project riscv-openocd --prefix=$RISCV --enable-remote-bitbang --enable-jtag_vpi --disable-werror
 build_project riscv-fesvr --prefix=$RISCV
 build_project riscv-isa-sim --prefix=$RISCV --with-fesvr=$RISCV
 build_project riscv-gnu-toolchain --prefix=$RISCV


### PR DESCRIPTION
It appears that newer GCC versions don't like some of our macros.  Since
OpenOCD defaults to --enable-werror, it'll blow up on those platforms.