### PR TITLE
Add missing dependency: zlib1g-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ flex, bison, autotools, libmpc, libmpfr, and libgmp. Ubuntu distribution
 installations will require this command to be run. If you have not installed
 these things yet, then run this:
 
-	O$ sudo apt-get install autoconf automake autotools-dev curl device-tree-compiler libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc
+	O$ sudo apt-get install autoconf automake autotools-dev curl device-tree-compiler libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev
 
 Before we start installation, we need to set the
 `$RISCV` environment variable. The variable is used throughout the


### PR DESCRIPTION
zlib1g-dev is listed in the quick start section, but not in this location.  If you skip the quick start and only install the packages listed in the "Obtaining and Compiling the Sources" section, ./build.sh will fail due to missing zlib (on systems that don't have this library already -- my fresh Ubuntu 16.04 vmware install did not).