### PR TITLE
Fix benchmarks invocation.

### DIFF
--- a/regression.sh
+++ b/regression.sh
@@ -15,7 +15,7 @@ export RISCV=${base_dir}/regression_install
 # test the tools
 export PATH="$RISCV/bin:$PATH"
 make -C ${base_dir}/riscv-tests/isa/ run
-make -C ${base_dir}/riscv-tests/benchmarks/ run-riscv
+make -C ${base_dir}/riscv-tests/benchmarks/ run riscv
 
 # test the pk
 echo -e '#include <stdio.h>\n int main(void) { printf("Hello world!\\n"); return 0; }' > hello.c


### PR DESCRIPTION
The riscv-tests/benchmarks/Makefile changed in
a83e3b9243e57a50de283fc07d5b6c81c0443b3d, renaming the run-riscv target.