### PR TITLE
Fixed Fedora required packages list (up to date with Fedora 27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Ubuntu packages needed:
 
 Fedora packages needed:
 
-	$ sudo dnf install autoconf automake @development-tools curl dtc libmpc-devel mpfr-devel gmp-devel gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib-devel
+	$ sudo dnf install autoconf automake @development-tools curl dtc libmpc-devel mpfr-devel gmp-devel libusb-devel gawk gcc-c++ bison flex texinfo gperf libtool patchutils bc zlib-devel
 
 _Note:_ This requires a compiler with C++11 support (e.g. GCC >= 4.8).
 To use a compiler different than the default, use:


### PR DESCRIPTION
The package 'build-essential' does not exist on Fedora/RHEL, and so this will cause an issue installing any of the listed packages with it included.

Generally, a collection of make, automake, gcc, gcc-c++ should suffice, especially with the group @development-tools included.

Adjusted install list:

autoconf automake @development-tools curl dtc libmpc-devel mpfr-devel gmp-devel libusb-devel  gawk gcc-c++ bison flex texinfo gperf libtoolpatchutils bc zlib-devel

libusb-devel was added at the behest of a warning sent by ./build.sh, gcc-g++ isn't included in @development-tools and so that was added as well.

Tested running through this readme with the adjustment of removing `build-essential` on a freshly created VM of Fedora 27.