### PR TITLE
Check autotools/automake version for OpenOCD build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,17 @@
 
 echo "Starting RISC-V Toolchain build process"
 
+check_version() {
+    $1 --version | awk "NR==1 {if (\$NF>$2) {exit 0} exit 1}" || (
+        echo $3 requires at least version $2 of $1. Aborting.
+        exit 1
+    )
+}
+
+check_version automake 1.14 "OpenOCD build"
+check_version autoconf 2.64 "OpenOCD build"
 build_project riscv-openocd --prefix=$RISCV --enable-remote-bitbang --enable-jtag_vpi --disable-werror
+
 build_project riscv-fesvr --prefix=$RISCV
 build_project riscv-isa-sim --prefix=$RISCV --with-fesvr=$RISCV
 build_project riscv-gnu-toolchain --prefix=$RISCV


### PR DESCRIPTION
Hopefully this will cut down on the number of riscv-tools-doesn't-build
questions we get. Sample output:
Starting RISC-V Toolchain build process
OpenOCD build requires at least version 2.74 of autoconf. Aborting.

(Note OpenOCD requires autoconf 2.64, but changed to 2.74 for this
test.)