### PR TITLE
Trivial: Add libexpat to dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repo provides guides and references:
 
 Ubuntu packages needed:
 
-	$ sudo apt-get install autoconf automake autotools-dev curl device-tree-compiler libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev
+	$ sudo apt-get install autoconf automake autotools-dev curl device-tree-compiler libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat1-dev
 
 
 _Note:_ This requires a compiler with C++11 support (e.g. GCC >= 4.8).


### PR DESCRIPTION
libexpat1-dev is also needed for building