### PR TITLE
Trivial: Add another dependency for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repo provides guides and references:
 
 Ubuntu packages needed:
 
-	$ sudo apt-get install autoconf automake autotools-dev curl device-tree-compiler libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat1-dev
+	$ sudo apt-get install autoconf automake autotools-dev curl device-tree-compiler libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat1-dev pkg-config
 
 
 _Note:_ This requires a compiler with C++11 support (e.g. GCC >= 4.8).


### PR DESCRIPTION
Sorry, should have finished the docker run. Another missing packet. With that it runs `FROM ubuntu:18.04` now.